### PR TITLE
qualify name of app-eselect/eselect-repository

### DIFF
--- a/prepare.sh
+++ b/prepare.sh
@@ -82,7 +82,7 @@ fi
 echo "installing pinebookpro-overlay, this will take an even longer while"
 emerge -u portage
 emerge -u dev-vcs/git
-emerge -u eselect-repository
+emerge -u app-eselect/eselect-repository
 mkdir -p /etc/portage/repos.conf
 eselect repository add pinebookpro-overlay git https://github.com/Jannik2099/pinebookpro-overlay.git
 emerge --sync pinebookpro-overlay


### PR DESCRIPTION
On my run on dec 7 2020, this line errored - sorry, i rebooted without saving logs, so it'd be hard to prove - but it worked when I qualified the name.